### PR TITLE
fix error: require_relative fetch file not found

### DIFF
--- a/useragents.gemspec
+++ b/useragents.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.date          = '2017-06-19'
   s.description   = 'Generate a random User-Agent for you'
   s.email         = 'debbbbie@163.com'
-  s.files         = ['useragents.gemspec', 'lib/useragents.rb', 'lib/core_ext/blank.rb', 'spec/useragents_spec.rb', 'README.md', 'LICENSE']
+  s.files         = ['useragents.gemspec', 'lib/useragents.rb', 'lib/core_ext/blank.rb', 'lib/useragents/fetch.rb', 'spec/useragents_spec.rb', 'lib/useragents.txt', 'README.md', 'LICENSE']
   s.homepage      = 'https://github.com/debbbbie/useragents-rb'
   s.require_paths = ['lib']
   s.summary       = 'Generate a random User-Agent for you, use for spiders or anything.'


### PR DESCRIPTION
fix this issue #6 
by adding `lib/useragents/fetch.rb and ` and `lib/useragents.txt` to the gemspec file